### PR TITLE
fix for range bad stmt runtime error

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -615,9 +615,11 @@ const (
 )
 
 func (p *forRangeStmt) End(cb *CodeBuilder) {
+	if p.stmt == nil {
+		return
+	}
 	stmts, flows := cb.endBlockStmt(&p.old)
 	cb.current.flows |= (flows &^ (flowFlagBreak | flowFlagContinue))
-
 	if n := p.udt; n == 0 {
 		p.stmt.Body = p.handleFor(&ast.BlockStmt{List: stmts}, 1)
 		cb.emitStmt(p.stmt)


### PR DESCRIPTION
fix for range bad stmt runtime error
```
for k, v := range array {
}
```
gop run demo and panic
```
compile: ./main.gop:4:18: undefined: array
runtime error: invalid memory address or nil pointer dereference
```