### PR TITLE
markUsedBy check PkgRef.Types is nil

### DIFF
--- a/package.go
+++ b/package.go
@@ -180,7 +180,7 @@ retry:
 			if sym, ok := x.(*ast.Ident); ok {
 				name := sym.Name
 				for _, at := range p.importPkgs {
-					if at.Types.Name() == name { // pkg.Object
+					if at.Types != nil && at.Types.Name() == name { // pkg.Object
 						at.markUsed(sym)
 					}
 				}


### PR DESCRIPTION
fix this bug

demo.gop
```
import "fmt"
import "os"

println(1/2r)
```
gop run demo.gop
`panic: runtime error: invalid memory address or nil pointer dereference`