### PR TITLE
untyped big type to default

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1112,10 +1112,9 @@ func matchType(pkg *Package, arg *internal.Elem, param types.Type, at interface{
 	retry:
 		switch t := typ.(type) {
 		case *types.Interface:
-			if utTypeToDefault(pkg, arg.Type.(*types.Named), arg) {
-				if t.NumMethods() == 0 {
-					return nil
-				}
+			arg.Type = DefaultConv(pkg, arg.Type, arg)
+			if t.NumMethods() == 0 {
+				return nil
 			}
 		case *types.Named:
 			typ = t.Underlying()
@@ -1202,18 +1201,6 @@ func boundElementType(pkg *Package, elts []*internal.Elem, base, max, step int) 
 		}
 	}
 	return tBound
-}
-
-func utTypeToDefault(pkg *Package, t *types.Named, arg *internal.Elem) bool {
-	ut := pkg.Import(t.Obj().Pkg().Path())
-	if tname := ut.Ref(t.Obj().Name() + "_Default"); tname != nil {
-		if named, ok := tname.Type().(*types.Named); ok {
-			arg.Val = pkg.cb.Val(ut.Ref(named.Obj().Name())).Val(arg).Call(1).stk.Pop().Val
-			arg.Type = tname.Type()
-			return true
-		}
-	}
-	return false
 }
 
 // -----------------------------------------------------------------------------

--- a/ast.go
+++ b/ast.go
@@ -1105,16 +1105,24 @@ func matchType(pkg *Package, arg *internal.Elem, param types.Type, at interface{
 		}
 		log.Printf("==> MatchType %v%s, %v\n", arg.Type, cval, param)
 	}
-	switch t := param.(type) {
-	case *types.Interface:
-		if t.NumMethods() == 0 {
-			switch arg.Type {
-			case pkg.utBigInt, pkg.utBigRat, pkg.utBigFlt:
-				if utTypeToDefault(pkg, arg.Type.(*types.Named), arg) {
+	// check untyped big int/rat/flt => interface
+	switch arg.Type {
+	case pkg.utBigInt, pkg.utBigRat, pkg.utBigFlt:
+		typ := param
+	retry:
+		switch t := typ.(type) {
+		case *types.Interface:
+			if utTypeToDefault(pkg, arg.Type.(*types.Named), arg) {
+				if t.NumMethods() == 0 {
 					return nil
 				}
 			}
+		case *types.Named:
+			typ = t.Underlying()
+			goto retry
 		}
+	}
+	switch t := param.(type) {
 	case *types.Named:
 		if t2, ok := arg.Type.(*types.Basic); ok {
 			if t == pkg.utBigInt {

--- a/codebuild.go
+++ b/codebuild.go
@@ -1451,6 +1451,10 @@ func (p *CodeBuilder) Member(name string, flag MemberFlag, src ...ast.Node) (kin
 	if debugInstr {
 		log.Println("Member", name, flag, "//", arg.Type)
 	}
+	switch arg.Type {
+	case p.pkg.utBigInt, p.pkg.utBigRat, p.pkg.utBigFlt:
+		utTypeToDefault(p.pkg, arg.Type.(*types.Named), arg)
+	}
 	at := arg.Type
 	if flag == MemberFlagRef {
 		kind = p.refMember(at, name, arg.Val)

--- a/codebuild.go
+++ b/codebuild.go
@@ -1453,7 +1453,7 @@ func (p *CodeBuilder) Member(name string, flag MemberFlag, src ...ast.Node) (kin
 	}
 	switch arg.Type {
 	case p.pkg.utBigInt, p.pkg.utBigRat, p.pkg.utBigFlt:
-		DefaultConv(p.pkg, arg.Type, arg)
+		arg.Type = DefaultConv(p.pkg, arg.Type, arg)
 	}
 	at := arg.Type
 	if flag == MemberFlagRef {

--- a/codebuild.go
+++ b/codebuild.go
@@ -1453,7 +1453,7 @@ func (p *CodeBuilder) Member(name string, flag MemberFlag, src ...ast.Node) (kin
 	}
 	switch arg.Type {
 	case p.pkg.utBigInt, p.pkg.utBigRat, p.pkg.utBigFlt:
-		utTypeToDefault(p.pkg, arg.Type.(*types.Named), arg)
+		DefaultConv(p.pkg, arg.Type, arg)
 	}
 	at := arg.Type
 	if flag == MemberFlagRef {

--- a/gop_test.go
+++ b/gop_test.go
@@ -1019,8 +1019,8 @@ import (
 )
 
 func main() {
-	fmt.Println(builtin.Gop_bigint_Cast__1(big.NewInt(1)))
-	fmt.Println(builtin.Gop_bigrat_Cast__1(builtin.Gop_bigint_Init__2(big.NewRat(1, 2))))
+	fmt.Println(builtin.Gop_bigint_Init__1(big.NewInt(1)))
+	fmt.Println(builtin.Gop_bigrat_Init__2(big.NewRat(1, 2)))
 }
 `)
 }
@@ -1069,7 +1069,7 @@ type A interface {
 }
 
 func main() {
-	var a A = builtin.Gop_bigint_Cast__1(big.NewInt(1))
+	var a A = builtin.Gop_bigint_Init__1(big.NewInt(1))
 	fmt.Println(a.Int64())
 }
 `)

--- a/gop_test.go
+++ b/gop_test.go
@@ -1038,8 +1038,8 @@ import (
 )
 
 func main() {
-	builtin.Gop_bigint_Cast__1(big.NewInt(1)).Int64()
-	builtin.Gop_bigrat_Cast__1(builtin.Gop_bigint_Init__2(big.NewRat(1, 2))).Float64()
+	builtin.Gop_bigint_Init__1(big.NewInt(1)).Int64()
+	builtin.Gop_bigrat_Init__2(big.NewRat(1, 2)).Float64()
 }
 `)
 }

--- a/gop_test.go
+++ b/gop_test.go
@@ -1027,7 +1027,6 @@ func main() {
 
 func TestUntypedBigDefaultCall(t *testing.T) {
 	pkg := newGopMainPackage()
-	pkg.Import("github.com/goplus/gox/internal/builtin").EnsureImported()
 	pkg.NewFunc(nil, "main", nil, nil, false).BodyStart(pkg).
 		UntypedBigInt(big.NewInt(1)).MemberVal("Int64").Call(0).EndStmt().
 		UntypedBigRat(big.NewRat(1, 2)).MemberVal("Float64").Call(0).EndStmt().End()
@@ -1041,6 +1040,37 @@ import (
 func main() {
 	builtin.Gop_bigint_Cast__1(big.NewInt(1)).Int64()
 	builtin.Gop_bigrat_Cast__1(builtin.Gop_bigint_Init__2(big.NewRat(1, 2))).Float64()
+}
+`)
+}
+
+func TestUntypedBigIntToInterface(t *testing.T) {
+	pkg := newGopMainPackage()
+	methods := []*types.Func{
+		types.NewFunc(token.NoPos, pkg.Types, "Int64", types.NewSignature(nil, nil,
+			types.NewTuple(types.NewVar(token.NoPos, nil, "v", types.Typ[types.Int64])), false)),
+	}
+	tyInterf := types.NewInterfaceType(methods, nil).Complete()
+	tyA := pkg.NewType("A").InitType(pkg, tyInterf)
+	pkg.NewFunc(nil, "main", nil, nil, false).BodyStart(pkg).
+		NewVarStart(tyA, "a").UntypedBigInt(big.NewInt(1)).EndInit(1).
+		Val(ctxRef(pkg, "println")).
+		Val(ctxRef(pkg, "a")).MemberVal("Int64").Call(0).Call(1).EndStmt().End()
+	domTest(t, pkg, `package main
+
+import (
+	fmt "fmt"
+	builtin "github.com/goplus/gox/internal/builtin"
+	big "math/big"
+)
+
+type A interface {
+	Int64() (v int64)
+}
+
+func main() {
+	var a A = builtin.Gop_bigint_Cast__1(big.NewInt(1))
+	fmt.Println(a.Int64())
 }
 `)
 }

--- a/gop_test.go
+++ b/gop_test.go
@@ -1003,6 +1003,46 @@ func TestBigIntCastUntypedFloatError(t *testing.T) {
 		Call(1).EndInit(1)
 }
 
-//
+func TestUntypedBigDefault(t *testing.T) {
+	pkg := newGopMainPackage()
+	pkg.NewFunc(nil, "main", nil, nil, false).BodyStart(pkg).
+		Val(ctxRef(pkg, "println")).
+		UntypedBigInt(big.NewInt(1)).Call(1).EndStmt().
+		Val(ctxRef(pkg, "println")).
+		UntypedBigRat(big.NewRat(1, 2)).Call(1).EndStmt().End()
+	domTest(t, pkg, `package main
+
+import (
+	fmt "fmt"
+	builtin "github.com/goplus/gox/internal/builtin"
+	big "math/big"
+)
+
+func main() {
+	fmt.Println(builtin.Gop_bigint_Cast__1(big.NewInt(1)))
+	fmt.Println(builtin.Gop_bigrat_Cast__1(builtin.Gop_bigint_Init__2(big.NewRat(1, 2))))
+}
+`)
+}
+
+func TestUntypedBigDefaultCall(t *testing.T) {
+	pkg := newGopMainPackage()
+	pkg.Import("github.com/goplus/gox/internal/builtin").EnsureImported()
+	pkg.NewFunc(nil, "main", nil, nil, false).BodyStart(pkg).
+		UntypedBigInt(big.NewInt(1)).MemberVal("Int64").Call(0).EndStmt().
+		UntypedBigRat(big.NewRat(1, 2)).MemberVal("Float64").Call(0).EndStmt().End()
+	domTest(t, pkg, `package main
+
+import (
+	builtin "github.com/goplus/gox/internal/builtin"
+	big "math/big"
+)
+
+func main() {
+	builtin.Gop_bigint_Cast__1(big.NewInt(1)).Int64()
+	builtin.Gop_bigrat_Cast__1(builtin.Gop_bigint_Init__2(big.NewRat(1, 2))).Float64()
+}
+`)
+}
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
fix https://github.com/goplus/gop/issues/1305

- empty interface convert
```
printf("%T\n",1r)
```
```
package main

import (
	fmt "fmt"
	ng "github.com/goplus/gop/builtin/ng"
	big "math/big"
)

func main() {
//line main.gop:1
	fmt.Printf("%T\n", ng.Bigint_Init__1(big.NewInt(1)))
}
```

- interface convert
```
type A interface{ Int64() int64 }

var a A = 1r
println a.Int64()
```
```
package main

import (
	fmt "fmt"
	ng "github.com/goplus/gop/builtin/ng"
	big "math/big"
)

type A interface {
	Int64() int64
}

var a A = ng.Bigint_Init__1(big.NewInt(1))

func main() {
//line main.gop:4
	fmt.Println(a.Int64())
}

```

-  method call
```
println 1r.Int64()
```
```
package main

import (
	fmt "fmt"
	ng "github.com/goplus/gop/builtin/ng"
	big "math/big"
)

func main() {
//line main.gop:1
	fmt.Println(ng.Bigint_Init__1(big.NewInt(1)).Int64())
}

```

