### PR TITLE
checkDivisionByZero only check int if first varable

### DIFF
--- a/codebuild.go
+++ b/codebuild.go
@@ -1759,12 +1759,24 @@ func (p *CodeBuilder) AssignOp(op token.Token, src ...ast.Node) *CodeBuilder {
 	return p
 }
 
-func checkDivisionByZero(cb *CodeBuilder, arg *internal.Elem) {
-	if c := arg.CVal; c != nil {
+func checkDivisionByZero(cb *CodeBuilder, a, b *internal.Elem) {
+	if a.CVal == nil {
+		if isNormalInt(cb, a) {
+			if c := b.CVal; c != nil {
+				switch c.Kind() {
+				case constant.Int, constant.Float:
+					if constant.Sign(c) == 0 {
+						_, pos := cb.loadExpr(b.Src)
+						cb.panicCodeError(&pos, "invalid operation: division by zero")
+					}
+				}
+			}
+		}
+	} else if c := b.CVal; c != nil {
 		switch c.Kind() {
 		case constant.Int, constant.Float, constant.Complex:
 			if constant.Sign(c) == 0 {
-				_, pos := cb.loadExpr(arg.Src)
+				_, pos := cb.loadExpr(b.Src)
 				cb.panicCodeError(&pos, "invalid operation: division by zero")
 			}
 		}
@@ -1795,7 +1807,7 @@ func callAssignOp(pkg *Package, tok token.Token, args []*internal.Elem, src []as
 		panic("TODO: operator not matched")
 	}
 	if tok == token.QUO_ASSIGN {
-		checkDivisionByZero(&pkg.cb, args[1])
+		checkDivisionByZero(&pkg.cb, &internal.Elem{Val: args[0].Val, Type: args[0].Type.(*refType).typ}, args[1])
 	}
 	fn := &internal.Elem{
 		Val: ident(op.Name()), Type: op.Type(),
@@ -1952,7 +1964,7 @@ retry:
 		goto retry
 	}
 	if op == token.QUO {
-		checkDivisionByZero(cb, args[1])
+		checkDivisionByZero(cb, args[0], args[1])
 	}
 	if op == token.EQL || op == token.NEQ {
 		if !ComparableTo(pkg, args[0], args[1]) {

--- a/error_msg_test.go
+++ b/error_msg_test.go
@@ -1222,46 +1222,10 @@ func TestDivisionByZero(t *testing.T) {
 	codeErrorTest(t,
 		`./foo.gop:1:3: invalid operation: division by zero`,
 		func(pkg *gox.Package) {
-			typ := types.Typ[types.Float64]
-			pkg.NewFunc(nil, "main", nil, nil, false).BodyStart(pkg).
-				NewVar(typ, "a").
-				Val(ctxRef(pkg, "a")).Val(0.0, source("0.0", 1, 3)).BinaryOp(token.QUO).
-				End()
-		})
-	codeErrorTest(t,
-		`./foo.gop:1:3: invalid operation: division by zero`,
-		func(pkg *gox.Package) {
-			typ := types.Typ[types.Complex128]
-			pkg.NewFunc(nil, "main", nil, nil, false).BodyStart(pkg).
-				NewVar(typ, "a").
-				Val(ctxRef(pkg, "a")).Val(&ast.BasicLit{Kind: token.IMAG, Value: "0i"}, source("0i", 1, 3)).BinaryOp(token.QUO).
-				End()
-		})
-	codeErrorTest(t,
-		`./foo.gop:1:3: invalid operation: division by zero`,
-		func(pkg *gox.Package) {
 			typ := types.Typ[types.Int]
 			pkg.NewFunc(nil, "main", nil, nil, false).BodyStart(pkg).
 				NewVar(typ, "a").
 				VarRef(ctxRef(pkg, "a")).Val(0, source("0", 1, 3)).AssignOp(token.QUO_ASSIGN).
-				End()
-		})
-	codeErrorTest(t,
-		`./foo.gop:1:3: invalid operation: division by zero`,
-		func(pkg *gox.Package) {
-			typ := types.Typ[types.Float64]
-			pkg.NewFunc(nil, "main", nil, nil, false).BodyStart(pkg).
-				NewVar(typ, "a").
-				VarRef(ctxRef(pkg, "a")).Val(0.0, source("0.0", 1, 3)).AssignOp(token.QUO_ASSIGN).
-				End()
-		})
-	codeErrorTest(t,
-		`./foo.gop:1:3: invalid operation: division by zero`,
-		func(pkg *gox.Package) {
-			typ := types.Typ[types.Complex128]
-			pkg.NewFunc(nil, "main", nil, nil, false).BodyStart(pkg).
-				NewVar(typ, "a").
-				VarRef(ctxRef(pkg, "a")).Val(&ast.BasicLit{Kind: token.IMAG, Value: "0i"}, source("0i", 1, 3)).AssignOp(token.QUO_ASSIGN).
 				End()
 		})
 }


### PR DESCRIPTION
invalid operation: division by zero
```
// var int/0 or const/0
var a int
a /= 0  
a /= 0.0
println a/0
println a/0.0

1/0
1.1/0
1i/0i
```
no division by zero
```
// var float and complex
var a float64
a/0 // Nan
var b float64 = 1
b/0 // +Inf
var c float64 = -1
c/0 // -Inf
```