### PR TITLE
fix overload methods of generic type

### DIFF
--- a/func.go
+++ b/func.go
@@ -282,7 +282,7 @@ func NewOverloadFunc(pos token.Pos, pkg *types.Package, name string, funcs ...ty
 	return types.NewTypeName(pos, pkg, name, &overloadFuncType{funcs})
 }
 
-const gop_overload = "__gop_overload__"
+const gop_overload = "__gop_overload__:"
 
 func NewOverloadMethod(typ *types.Named, pos token.Pos, pkg *types.Package, name string, funcs ...types.Object) *types.Func {
 	oft := &overloadFuncType{funcs}
@@ -290,7 +290,7 @@ func NewOverloadMethod(typ *types.Named, pos token.Pos, pkg *types.Package, name
 	for _, f := range funcs {
 		nameList = append(nameList, f.Name())
 	}
-	recv := types.NewParam(token.NoPos, pkg, "__gop_overload__"+strings.Join(nameList, ";"), oft)
+	recv := types.NewParam(token.NoPos, pkg, gop_overload+strings.Join(nameList, ";"), oft)
 	sig := types.NewSignature(recv, nil, nil, false)
 	ofn := types.NewFunc(pos, pkg, name, sig)
 	typ.AddMethod(ofn)

--- a/func.go
+++ b/func.go
@@ -19,6 +19,7 @@ import (
 	"go/token"
 	"go/types"
 	"log"
+	"strings"
 
 	"github.com/goplus/gox/internal"
 )
@@ -281,9 +282,15 @@ func NewOverloadFunc(pos token.Pos, pkg *types.Package, name string, funcs ...ty
 	return types.NewTypeName(pos, pkg, name, &overloadFuncType{funcs})
 }
 
+const gop_overload = "__gop_overload__"
+
 func NewOverloadMethod(typ *types.Named, pos token.Pos, pkg *types.Package, name string, funcs ...types.Object) *types.Func {
 	oft := &overloadFuncType{funcs}
-	recv := types.NewParam(token.NoPos, pkg, "", oft)
+	var nameList []string
+	for _, f := range funcs {
+		nameList = append(nameList, f.Name())
+	}
+	recv := types.NewParam(token.NoPos, pkg, "__gop_overload__"+strings.Join(nameList, ";"), oft)
 	sig := types.NewSignature(recv, nil, nil, false)
 	ofn := types.NewFunc(pos, pkg, name, sig)
 	typ.AddMethod(ofn)


### PR DESCRIPTION
fix https://github.com/goplus/gop/issues/1396

```
const GopPackage = true

type Data[T any] struct {
	v T
}

func (p *Data[T]) Foo__0() {
}
func (p *Data[T]) Foo__1(a string, t T) {
}
```

NewOverloadMethod
```
recv type: *overloadFuncType
recv name: __gop_overload__:Foo__0;Foo__1
func (name type) Foo()
```
