### PR TITLE
sigFuncEx change new func type for overload

### DIFF
--- a/builtin_test.go
+++ b/builtin_test.go
@@ -501,8 +501,8 @@ func typString(pkg *Package, t types.Type) string {
 func TestMethodAutoProperty(t *testing.T) {
 	typs := []types.Type{
 		tyInt,
-		sigFuncEx(nil, &TyOverloadFunc{}),
-		sigFuncEx(nil, &TyTemplateRecvMethod{types.NewParam(0, nil, "", tyInt)}),
+		sigFuncEx(nil, nil, &TyOverloadFunc{}),
+		sigFuncEx(nil, nil, &TyTemplateRecvMethod{types.NewParam(0, nil, "", tyInt)}),
 	}
 	for _, typ := range typs {
 		if methodHasAutoProperty(typ, 0) {
@@ -512,7 +512,7 @@ func TestMethodAutoProperty(t *testing.T) {
 }
 
 func TestIsType(t *testing.T) {
-	if isType(sigFuncEx(nil, &TyOverloadFunc{})) {
+	if isType(sigFuncEx(nil, nil, &TyOverloadFunc{})) {
 		t.Fatal("TestIsType: isType(TyOverloadFunc)")
 	}
 }
@@ -889,7 +889,7 @@ func TestCheckSignature(t *testing.T) {
 	arg := types.NewParam(token.NoPos, pkg, "", sig)
 	sig2 := types.NewSignatureType(nil, nil, nil, types.NewTuple(arg, arg), nil, false)
 	o := types.NewFunc(token.NoPos, pkg, "bar", sig2)
-	if CheckSignature(sigFuncEx(pkg, &TyTemplateRecvMethod{Func: o}), 0, 0) == nil {
+	if CheckSignature(sigFuncEx(pkg, nil, &TyTemplateRecvMethod{Func: o}), 0, 0) == nil {
 		t.Fatal("TestCheckSignature failed: TemplateRecvMethod CheckSignature == nil")
 	}
 
@@ -901,7 +901,7 @@ func TestCheckSignature(t *testing.T) {
 		t.Fatal("func bar has autoprop?")
 	}
 
-	if CheckSignature(sigFuncEx(pkg, &TyTemplateRecvMethod{Func: of}), 0, 0) == nil {
+	if CheckSignature(sigFuncEx(pkg, nil, &TyTemplateRecvMethod{Func: of}), 0, 0) == nil {
 		t.Fatal("TestCheckSignature failed: TemplateRecvMethod OverloadFunc CheckSignature == nil")
 	}
 
@@ -931,7 +931,7 @@ func TestCheckSignatures(t *testing.T) {
 	arg := types.NewParam(token.NoPos, pkg, "", sig)
 	sig2 := types.NewSignatureType(nil, nil, nil, types.NewTuple(arg, arg), nil, false)
 	o := types.NewFunc(token.NoPos, pkg, "bar", sig2)
-	if CheckSignatures(sigFuncEx(pkg, &TyTemplateRecvMethod{Func: o}), 0, 0) == nil {
+	if CheckSignatures(sigFuncEx(pkg, nil, &TyTemplateRecvMethod{Func: o}), 0, 0) == nil {
 		t.Fatal("TestCheckSignatures failed: TemplateRecvMethod CheckSignatures == nil")
 	}
 	sig3 := types.NewSignatureType(nil, nil, nil, types.NewTuple(arg, arg, arg), nil, false)
@@ -945,7 +945,7 @@ func TestCheckSignatures(t *testing.T) {
 		t.Fatal("func bar has autoprop?")
 	}
 
-	if CheckSignatures(sigFuncEx(pkg, &TyTemplateRecvMethod{Func: of}), 0, 0) == nil {
+	if CheckSignatures(sigFuncEx(pkg, nil, &TyTemplateRecvMethod{Func: of}), 0, 0) == nil {
 		t.Fatal("TestCheckSignatures failed: TemplateRecvMethod OverloadFunc CheckSignatures == nil")
 	}
 

--- a/func_ext.go
+++ b/func_ext.go
@@ -36,20 +36,20 @@ func IsFunc(t types.Type) bool {
 }
 
 // CheckFuncEx returns if specified function is a FuncEx or not.
-func CheckFuncEx(sig *types.Signature) (t TyFuncEx, ok bool) {
+func CheckFuncEx(sig *types.Signature) (TyFuncEx, bool) {
 	if sig.Params().Len() == 1 && sig.Variadic() {
 		if typ, ok := sig.Params().At(0).Type().(*types.Slice); ok {
 			if typ, ok := typ.Elem().(*types.Interface); ok && typ.NumMethods() == 1 {
 				if sig, ok := typ.Method(0).Type().(*types.Signature); ok {
 					if recv := sig.Recv(); recv != nil {
-						t, ok = recv.Type().(TyFuncEx)
+						t, ok := recv.Type().(TyFuncEx)
 						return t, ok
 					}
 				}
 			}
 		}
 	}
-	return
+	return nil, false
 }
 
 // sigFuncEx return func type (args ...interface{__gop_overload__()})

--- a/func_ext.go
+++ b/func_ext.go
@@ -75,8 +75,8 @@ func NewOverloadFunc(pos token.Pos, pkg *types.Package, name string, funcs ...ty
 }
 
 func CheckOverloadFunc(sig *types.Signature) (funcs []types.Object, ok bool) {
-	if recv := sig.Recv(); recv != nil {
-		if oft, ok := recv.Type().(*TyOverloadFunc); ok {
+	if t, ok := CheckFuncEx(sig); ok {
+		if oft, ok := t.(*TyOverloadFunc); ok {
 			return oft.Funcs, true
 		}
 	}
@@ -99,8 +99,8 @@ func NewOverloadMethod(typ *types.Named, pos token.Pos, pkg *types.Package, name
 }
 
 func CheckOverloadMethod(sig *types.Signature) (methods []types.Object, ok bool) {
-	if recv := sig.Recv(); recv != nil {
-		if oft, ok := recv.Type().(*TyOverloadMethod); ok {
+	if t, ok := CheckFuncEx(sig); ok {
+		if oft, ok := t.(*TyOverloadMethod); ok {
 			return oft.Methods, true
 		}
 	}
@@ -135,8 +135,8 @@ func overloadFnHasAutoProperty(fns []types.Object, n int) bool {
 
 func methodHasAutoProperty(typ types.Type, n int) bool {
 	if sig, ok := typ.(*types.Signature); ok {
-		if recv := sig.Recv(); recv != nil {
-			switch t := recv.Type().(type) {
+		if t, ok := CheckFuncEx(sig); ok {
+			switch t := t.(type) {
 			case *TyOverloadMethod:
 				// is overload method
 				return overloadFnHasAutoProperty(t.Methods, n)
@@ -156,8 +156,8 @@ func methodHasAutoProperty(typ types.Type, n int) bool {
 // HasAutoProperty checks if specified type is a function without parameters or not.
 func HasAutoProperty(typ types.Type) bool {
 	if sig, ok := typ.(*types.Signature); ok {
-		if recv := sig.Recv(); recv != nil {
-			switch t := recv.Type().(type) {
+		if t, ok := CheckFuncEx(sig); ok {
+			switch t := t.(type) {
 			case *TyOverloadFunc:
 				// is overload func
 				for _, fn := range t.Funcs {
@@ -181,16 +181,16 @@ func HasAutoProperty(typ types.Type) bool {
 // If nin == -2, it means param idx is a SliceLit.
 func CheckSignature(typ types.Type, idx, nin int) *types.Signature {
 	if sig, ok := typ.(*types.Signature); ok {
-		if recv := sig.Recv(); recv != nil {
-			switch t := recv.Type().(type) {
+		if t, ok := CheckFuncEx(sig); ok {
+			switch t := t.(type) {
 			case *TyOverloadFunc:
 				return selOverloadFunc(t.Funcs, idx, nin)
 			case *TyOverloadMethod:
 				return selOverloadFunc(t.Methods, idx, nin)
 			case *TyTemplateRecvMethod:
 				if tsig, ok := t.Func.Type().(*types.Signature); ok {
-					if trecv := tsig.Recv(); trecv != nil {
-						if t, ok := trecv.Type().(*TyOverloadFunc); ok {
+					if tf, ok := CheckFuncEx(tsig); ok {
+						if t, ok := tf.(*TyOverloadFunc); ok {
 							return selOverloadFunc(t.Funcs, idx, nin)
 						}
 					}
@@ -209,16 +209,16 @@ func CheckSignature(typ types.Type, idx, nin int) *types.Signature {
 // If nin == -2, it means param idx is a SliceLit.
 func CheckSignatures(typ types.Type, idx, nin int) []*types.Signature {
 	if sig, ok := typ.(*types.Signature); ok {
-		if recv := sig.Recv(); recv != nil {
-			switch t := recv.Type().(type) {
+		if t, ok := CheckFuncEx(sig); ok {
+			switch t := t.(type) {
 			case *TyOverloadFunc:
 				return selOverloadFuncs(t.Funcs, idx, nin)
 			case *TyOverloadMethod:
 				return selOverloadFuncs(t.Methods, idx, nin)
 			case *TyTemplateRecvMethod:
 				if tsig, ok := t.Func.Type().(*types.Signature); ok {
-					if trecv := tsig.Recv(); trecv != nil {
-						if t, ok := trecv.Type().(*TyOverloadFunc); ok {
+					if tf, ok := CheckFuncEx(tsig); ok {
+						if t, ok := tf.(*TyOverloadFunc); ok {
 							return selOverloadFuncs(t.Funcs, idx, nin)
 						}
 					}


### PR DESCRIPTION
update overload data
```
func(args ...interface{__gop_overload__()})
```
func type param `interface{__gop_overload__()}` method `__gop_overload__` type is `func(*TyOverload)()`

go/types/interface.go:53
```
func NewInterfaceType(methods []*Func, embeddeds []Type) *Interface {
	if len(methods) == 0 && len(embeddeds) == 0 {
		return &emptyInterface
	}

	// set method receivers if necessary
	typ := (*Checker)(nil).newInterface()
	for _, m := range methods {
		if sig := m.typ.(*Signature); sig.recv == nil {
			sig.recv = NewVar(m.pos, m.pkg, "", typ)
		}
	}
        ....
```
