### PR TITLE
initThisGopPkg: add interface overload method to named

### DIFF
--- a/import.go
+++ b/import.go
@@ -124,8 +124,15 @@ func initThisGopPkg(pkg *types.Package) {
 			key := name[:len(name)-3]
 			overloads[key] = append(overloads[key], o)
 		} else if named, ok := o.Type().(*types.Named); ok {
-			for i, n := 0, named.NumMethods(); i < n; i++ {
-				m := named.Method(i)
+			var list methodList
+			switch t := named.Underlying().(type) {
+			case *types.Interface:
+				list = t // add interface overload method to named
+			default:
+				list = named
+			}
+			for i, n := 0, list.NumMethods(); i < n; i++ {
+				m := list.Method(i)
 				mName := m.Name()
 				if isOverloadFunc(mName) { // overload method
 					mthd := mName[:len(mName)-3]

--- a/internal/foo/foo.go
+++ b/internal/foo/foo.go
@@ -109,3 +109,11 @@ func (p Foo4) Gop_Enum(c func()) {
 }
 
 // -----------------------------------------------------------------------------
+
+type NodeSeter interface {
+	Len__0() int
+	Attr__0(k string, exactlyOne ...bool) (text string, err error)
+	Attr__1(k, v string) (ret NodeSeter)
+}
+
+// -----------------------------------------------------------------------------

--- a/package_test.go
+++ b/package_test.go
@@ -2645,6 +2645,38 @@ func bar(v foo.NodeSet) {
 `)
 }
 
+func TestOverloadInterfaceMethod(t *testing.T) {
+	pkg := newMainPackage()
+	foo := pkg.Import("github.com/goplus/gox/internal/foo")
+	nodeSet := foo.Ref("NodeSeter").Type()
+	v := pkg.NewParam(token.NoPos, "v", nodeSet)
+	pkg.NewFunc(nil, "bar", types.NewTuple(v), nil, false).BodyStart(pkg).
+		DefineVarStart(token.NoPos, "val", "err").Val(v).
+		Debug(func(cb *gox.CodeBuilder) {
+			if kind, err := cb.Member("attr", gox.MemberFlagAutoProperty); err == nil {
+				t.Fatal("cb.Member v.attr no error?", kind)
+			}
+			cb.Member("attr", gox.MemberFlagMethodAlias)
+		}).
+		Val("key").Call(1).EndInit(1).EndStmt().
+		Val(v).
+		Debug(func(cb *gox.CodeBuilder) {
+			cb.Member("len", gox.MemberFlagAutoProperty)
+		}).EndStmt().
+		VarRef(v).Val(v).MemberVal("Attr").Val("key").Val("val").Call(2).Assign(1).
+		End()
+	domTest(t, pkg, `package main
+
+import "github.com/goplus/gox/internal/foo"
+
+func bar(v foo.NodeSeter) {
+	val, err := v.Attr__0("key")
+	v.Len__0()
+	v = v.Attr__1("key", "val")
+}
+`)
+}
+
 func TestPkgVar(t *testing.T) {
 	pkg := newMainPackage()
 	flag := pkg.Import("flag")


### PR DESCRIPTION
```
type NodeSeter interface {
	Len__0() int
	Attr__0(k string, exactlyOne ...bool) (text string, err error)
	Attr__1(k, v string) (ret NodeSeter)
}
```

*types.Named.Underlying().(*types.Interface) => interface
```
interface {
	Len__0() int
	Attr__0(k string, exactlyOne ...bool) (text string, err error)
	Attr__1(k, v string) (ret NodeSeter)
}
```
*types.Named => add overload 
```
method Len(__gop_overload_args__ interface{_()})
method Attr(__gop_overload_args__ interface{_()})
```