### PR TITLE
matchFuncCall: fix bigint(uint64) to untyped int

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -784,9 +784,10 @@ retry:
 			args = newArgs
 		}
 	}
-
-	if err = matchFuncType(pkg, args, lhs, flags, sig, fn); err != nil {
-		return
+	if flags&instrFlagUntyped == 0 {
+		if err = matchFuncType(pkg, args, lhs, flags, sig, fn); err != nil {
+			return
+		}
 	}
 	tyRet := toRetType(sig.Results())
 	if tyRet != nil && flags&instrFlagUntyped != 0 {
@@ -802,6 +803,12 @@ retry:
 				tyRet = types.Typ[types.UntypedComplex]
 			} else if typ.Info()&types.IsString != 0 {
 				tyRet = types.Typ[types.UntypedString]
+			}
+		default:
+			if tyRet == pkg.utBigInt && cval != nil {
+				if v, ok := constant.Val(cval).(*big.Int); ok && v.IsUint64() {
+					tyRet = types.Typ[types.UntypedInt]
+				}
 			}
 		}
 	}

--- a/xgo_test.go
+++ b/xgo_test.go
@@ -370,6 +370,17 @@ var a = builtin.XGo_bigint_Init__1(big.NewInt(69))
 `)
 }
 
+func TestUntypedBigIntUint64(t *testing.T) {
+	pkg := newXGoMainPackage()
+	pkg.CB().NewVarStart(nil, "a").
+		Val(1).Val(64).BinaryOp(token.SHL).Val(1).BinaryOp(token.SUB).
+		EndInit(1)
+	domTest(t, pkg, `package main
+
+var a = 1<<64 - 1
+`)
+}
+
 func TestBigRatIncDec(t *testing.T) {
 	pkg := newXGoMainPackage()
 	big := pkg.Import("github.com/goplus/gogen/internal/builtin")


### PR DESCRIPTION
fix https://github.com/goplus/xgo/issues/2775